### PR TITLE
Feat/informative titles, forbidden exception, and "error 200" error page

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,8 @@ documentation at: `/swagger-ui.html`
     - `spring.liquibase.enabled=true`
     - Seeding is disabled. The application expects the database to be managed
     via Liquibase.
+
+---
+
+## Credits
+* [Kaomoji by SmileX](https://kaomoji.ru/en/): mascots of the website. download the [app](https://play.google.com/store/apps/details?id=ru.kaomoji.kaomojiapp)! ([paid version](https://play.google.com/store/apps/details?id=ru.kaomoji.kaomojiplus))

--- a/src/main/java/com/simple/Bookstore/Comment/CommentService.java
+++ b/src/main/java/com/simple/Bookstore/Comment/CommentService.java
@@ -1,5 +1,7 @@
 package com.simple.Bookstore.Comment;
 
+import com.simple.Bookstore.Exceptions.CommentNotFoundException;
+import com.simple.Bookstore.Exceptions.ForbiddenException;
 import com.simple.Bookstore.User.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,9 +15,13 @@ public interface CommentService {
 
     CommentResponseDTO createComment(User user, Long reviewId, CommentRequestDTO request);
 
-    CommentResponseDTO updateComment(User user, Long id, CommentRequestDTO request);
+    CommentResponseDTO updateComment(
+            User user,
+            Long id,
+            CommentRequestDTO request
+    ) throws CommentNotFoundException, ForbiddenException;
 
-    void deleteComment(User user, Long id);
+    void deleteComment(User user, Long id) throws CommentNotFoundException, ForbiddenException;
 
     Page<CommentProfileViewResponseDTO> findAllCommentsByUser(User user, Pageable pageable);
 

--- a/src/main/java/com/simple/Bookstore/Comment/CommentServiceImpl.java
+++ b/src/main/java/com/simple/Bookstore/Comment/CommentServiceImpl.java
@@ -1,8 +1,8 @@
 package com.simple.Bookstore.Comment;
 
 import com.simple.Bookstore.Exceptions.CommentNotFoundException;
+import com.simple.Bookstore.Exceptions.ForbiddenException;
 import com.simple.Bookstore.Exceptions.ReviewNotFoundException;
-import com.simple.Bookstore.Exceptions.UnauthorizedException;
 import com.simple.Bookstore.Review.Review;
 import com.simple.Bookstore.Review.ReviewRepository;
 import com.simple.Bookstore.User.User;
@@ -48,12 +48,16 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public CommentResponseDTO updateComment(User user, Long id, CommentRequestDTO request) {
+    public CommentResponseDTO updateComment(
+            User user,
+            Long id,
+            CommentRequestDTO request
+    ) throws CommentNotFoundException, ForbiddenException {
         Comment comment = commentRepository
                 .findById(id)
                 .orElseThrow(() -> new CommentNotFoundException(id));
         if (!comment.getProfile().getUser().getId().equals(user.getId()))
-            throw new UnauthorizedException("You are not authorized to edit this comment");
+            throw new ForbiddenException("You are not allowed to edit this comment");
 
         comment.setContent(request.content());
         comment.setEdited(true);
@@ -62,12 +66,12 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public void deleteComment(User user, Long id) {
+    public void deleteComment(User user, Long id) throws CommentNotFoundException, ForbiddenException {
         Comment comment = commentRepository
                 .findById(id)
                 .orElseThrow(() -> new CommentNotFoundException(id));
         if (!comment.getProfile().getUser().getId().equals(user.getId()))
-            throw new UnauthorizedException("You are not authorized to edit this comment");
+            throw new ForbiddenException("You are not allowed to edit this comment");
 
         commentRepository.deleteById(id);
     }

--- a/src/main/java/com/simple/Bookstore/Exceptions/ForbiddenException.java
+++ b/src/main/java/com/simple/Bookstore/Exceptions/ForbiddenException.java
@@ -1,7 +1,11 @@
 package com.simple.Bookstore.Exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
 public class ForbiddenException extends RuntimeException {
-  public ForbiddenException(String message) {
-    super(message);
-  }
+    public ForbiddenException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/simple/Bookstore/Exceptions/ForbiddenException.java
+++ b/src/main/java/com/simple/Bookstore/Exceptions/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.simple.Bookstore.Exceptions;
+
+public class ForbiddenException extends RuntimeException {
+  public ForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/simple/Bookstore/Exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/simple/Bookstore/Exceptions/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CommentNotFoundException.class)
     public String handleCommentNotFoundException(
-            BookNotFoundException ex,
+            CommentNotFoundException ex,
             HttpServletRequest request,
             HttpServletResponse response
     ) {
@@ -31,9 +31,21 @@ public class GlobalExceptionHandler {
         return "forward:/error";
     }
 
+    @ExceptionHandler(ForbiddenException.class)
+    public String handleForbiddenException(
+            ForbiddenException ex,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        request.setAttribute(CUSTOM_ERROR_TITLE_ATTRIBUTE, "Forbidden");
+        request.setAttribute(CUSTOM_ERROR_MESSAGE_ATTRIBUTE, ex.getMessage());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        return "forward:/error";
+    }
+
     @ExceptionHandler(ReviewNotFoundException.class)
     public String handleReviewNotFoundException(
-            BookNotFoundException ex,
+            ReviewNotFoundException ex,
             HttpServletRequest request,
             HttpServletResponse response
     ) {

--- a/src/main/java/com/simple/Bookstore/Review/ReviewService.java
+++ b/src/main/java/com/simple/Bookstore/Review/ReviewService.java
@@ -1,6 +1,7 @@
 package com.simple.Bookstore.Review;
 
 import com.simple.Bookstore.Exceptions.BookNotFoundException;
+import com.simple.Bookstore.Exceptions.ForbiddenException;
 import com.simple.Bookstore.Exceptions.ReviewNotFoundException;
 import com.simple.Bookstore.User.User;
 import org.springframework.data.domain.Page;
@@ -19,9 +20,10 @@ public interface ReviewService {
     ReviewResponseDTO createReview(User user, Long bookId, ReviewRequestDTO request)
             throws IllegalStateException, BookNotFoundException;
 
-    ReviewResponseDTO updateReview(User user, Long id, ReviewRequestDTO request);
+    ReviewResponseDTO updateReview(User user, Long id, ReviewRequestDTO request)
+            throws ForbiddenException, ReviewNotFoundException;
 
-    void deleteReview(User user, Long id);
+    void deleteReview(User user, Long id) throws ForbiddenException, ReviewNotFoundException;
 
     List<ReviewProfileViewResponseDTO> findLatestNReviews(int n, User user);
 

--- a/src/main/java/com/simple/Bookstore/Review/ReviewServiceImpl.java
+++ b/src/main/java/com/simple/Bookstore/Review/ReviewServiceImpl.java
@@ -3,8 +3,8 @@ package com.simple.Bookstore.Review;
 import com.simple.Bookstore.Book.Book;
 import com.simple.Bookstore.Book.BookRepository;
 import com.simple.Bookstore.Exceptions.BookNotFoundException;
+import com.simple.Bookstore.Exceptions.ForbiddenException;
 import com.simple.Bookstore.Exceptions.ReviewNotFoundException;
-import com.simple.Bookstore.Exceptions.UnauthorizedException;
 import com.simple.Bookstore.User.User;
 import com.simple.Bookstore.config.constants.PagingConstants;
 import com.simple.Bookstore.utils.ReviewMapper;
@@ -77,12 +77,16 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
-    public ReviewResponseDTO updateReview(User user, Long id, ReviewRequestDTO request) {
+    public ReviewResponseDTO updateReview(
+            User user,
+            Long id,
+            ReviewRequestDTO request
+    ) throws ForbiddenException, ReviewNotFoundException {
         Review review = reviewRepository
                 .findById(id)
                 .orElseThrow(() -> new ReviewNotFoundException(id));
         if (!review.getProfile().getUser().getId().equals(user.getId()))
-            throw new UnauthorizedException("You are not authorized to edit this review");
+            throw new ForbiddenException("You are not allowed to edit this review");
 
         review.setContent(request.content());
         review.setRating(request.rating());
@@ -92,12 +96,15 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
-    public void deleteReview(User user, Long id) {
+    public void deleteReview(
+            User user,
+            Long id
+    ) throws ForbiddenException, ReviewNotFoundException {
         Review review = reviewRepository
                 .findById(id)
                 .orElseThrow(() -> new ReviewNotFoundException(id));
         if (!review.getProfile().getUser().getId().equals(user.getId()))
-            throw new UnauthorizedException("You are not authorized to delete this review");
+            throw new ForbiddenException("You are not allowed to delete this review");
 
         reviewRepository.deleteById(id);
     }

--- a/src/main/java/com/simple/Bookstore/utils/presentation/Kaomoji/ErrorMascotFactory.java
+++ b/src/main/java/com/simple/Bookstore/utils/presentation/Kaomoji/ErrorMascotFactory.java
@@ -13,6 +13,13 @@ public class ErrorMascotFactory {
             new ErrorMascot("┬┴┬┴┤_・)", 204)
     );
 
+    private final static List<ErrorMascot> error403 = List.of(
+            new ErrorMascot("▓▒░(°◡°)░▒▓", 275),
+            new ErrorMascot("..・ヾ(。＞＜)シ", 204),
+            new ErrorMascot("＼(º □ º l|l)/", 203),
+            new ErrorMascot("〣( ºΔº )〣", 195)
+    );
+
     private final static List<ErrorMascot> error404 = List.of(
             new ErrorMascot("(￣_￣)・・・", 200),
             new ErrorMascot("(-_-;)・・・", 172),
@@ -50,6 +57,8 @@ public class ErrorMascotFactory {
         return getRandom(switch (statusCode) {
             case UNAUTHORIZED ->
                     error401;
+            case FORBIDDEN ->
+                    error403;
             case NOT_FOUND ->
                     error404;
             case CONFLICT ->

--- a/src/main/java/com/simple/Bookstore/utils/presentation/Kaomoji/ErrorMascotFactory.java
+++ b/src/main/java/com/simple/Bookstore/utils/presentation/Kaomoji/ErrorMascotFactory.java
@@ -6,6 +6,15 @@ import java.util.List;
 import java.util.Random;
 
 public class ErrorMascotFactory {
+    private final static List<ErrorMascot> ok200 = List.of(
+            new ErrorMascot("(⁄ ⁄>⁄ ▽ ⁄<⁄ ⁄)", 308),
+            new ErrorMascot("(⁄ ⁄•⁄ω⁄•⁄ ⁄)", 273),
+            new ErrorMascot("(„ಡωಡ„)", 191),
+            new ErrorMascot("(*/▽＼*)", 150),
+            new ErrorMascot("(*ﾉωﾉ)", 128),
+            new ErrorMascot("(*/ω＼)", 127)
+    );
+
     private final static List<ErrorMascot> error401 = List.of(
             new ErrorMascot("┬┴┬┴┤ヾ(･ω├┬┴┬┴", 378),
             new ErrorMascot("┬┴┬┴┤( ͡° ͜ʖ├┬┴┬┴", 359),
@@ -55,6 +64,8 @@ public class ErrorMascotFactory {
      */
     public static ErrorMascot random(HttpStatus statusCode) {
         return getRandom(switch (statusCode) {
+            case OK ->
+                    ok200;
             case UNAUTHORIZED ->
                     error401;
             case FORBIDDEN ->

--- a/src/main/java/com/simple/Bookstore/views/Error/CustomErrorController.java
+++ b/src/main/java/com/simple/Bookstore/views/Error/CustomErrorController.java
@@ -49,7 +49,9 @@ public class CustomErrorController implements ErrorController {
                         ? customMessageAttr.toString()
                         : (switch (httpStatus) {
                     case UNAUTHORIZED -> // 401
-                            "You are not authorized to perform this action";
+                            "You need to login to perform this action";
+                    case FORBIDDEN -> // 401
+                            "You are not allowed to perform this action";
                     case NOT_FOUND -> // 404
                             "Page not found. Check if the URL is correct.";
                     default ->

--- a/src/main/java/com/simple/Bookstore/views/Error/CustomErrorController.java
+++ b/src/main/java/com/simple/Bookstore/views/Error/CustomErrorController.java
@@ -48,6 +48,8 @@ public class CustomErrorController implements ErrorController {
                 customMessageAttr != null
                         ? customMessageAttr.toString()
                         : (switch (httpStatus) {
+                    case OK -> // 200 (when /error is manually visited)
+                            "Well, that's embarrassing. You aren't supposed to visit this page manually!!";
                     case UNAUTHORIZED -> // 401
                             "You need to login to perform this action";
                     case FORBIDDEN -> // 401

--- a/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewService.java
+++ b/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewService.java
@@ -1,5 +1,6 @@
 package com.simple.Bookstore.views.Profile;
 
+import com.simple.Bookstore.Exceptions.ForbiddenException;
 import com.simple.Bookstore.Exceptions.UnauthorizedException;
 import com.simple.Bookstore.Exceptions.UserNotFoundException;
 import com.simple.Bookstore.Profile.ProfileEditRequestDTO;
@@ -65,7 +66,7 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             Pageable pageable
-    );
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException;
 
     /**
      * @param currentUser  currently authenticated user. null if anonymous
@@ -79,7 +80,7 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             Pageable pageable
-    );
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException;
 
     /**
      * @param currentUser  currently authenticated user. null if anonymous
@@ -93,7 +94,7 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             ProfileEditRequestDTO editRequest
-    ) throws UnauthorizedException, UserNotFoundException;
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException;
 
     /**
      * @param currentUser  currently authenticated user. null if anonymous
@@ -107,7 +108,7 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             ProfileEditRequestDTO editRequest
-    ) throws UnauthorizedException, UserNotFoundException;
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException;
 
     /**
      * validates request that came from /profile/me/edit -> /profile/me/edit/confirm
@@ -124,7 +125,7 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             ProfileEditRequestDTO editRequest
-    ) throws IllegalStateException, UnauthorizedException, UserNotFoundException;
+    ) throws ForbiddenException, IllegalStateException, UnauthorizedException, UserNotFoundException;
 
     /**
      * @param currentUser   currently authenticated user. null if anonymous
@@ -138,7 +139,7 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             UserDeleteRequestDTO deleteRequest
-    ) throws UnauthorizedException, UserNotFoundException;
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException;
 
 
     /**
@@ -154,5 +155,5 @@ public interface ProfileViewService {
             User currentUser,
             String pathUsername,
             UserDeleteRequestDTO deleteRequest
-    ) throws IllegalStateException, UnauthorizedException, UserNotFoundException;
+    ) throws ForbiddenException, IllegalStateException, UnauthorizedException, UserNotFoundException;
 }

--- a/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewServiceImpl.java
+++ b/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewServiceImpl.java
@@ -4,6 +4,7 @@ import com.simple.Bookstore.Book.BookSearchResultDTO;
 import com.simple.Bookstore.Book.BookService;
 import com.simple.Bookstore.Comment.CommentProfileViewResponseDTO;
 import com.simple.Bookstore.Comment.CommentService;
+import com.simple.Bookstore.Exceptions.ForbiddenException;
 import com.simple.Bookstore.Exceptions.UnauthorizedException;
 import com.simple.Bookstore.Exceptions.UserNotFoundException;
 import com.simple.Bookstore.Profile.ProfileEditRequestDTO;
@@ -89,7 +90,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             Pageable pageable
-    ) throws UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException {
         User foundUser = validateEditDeleteAccess(currentUser, pathUsername);
         ProfileResponseDTO foundProfile = ProfileMapper.profileToResponseDTO(foundUser.getProfile());
         Page<ThemeResponseDTO> savedThemes = themeService.findSavedThemes(foundUser, pageable);
@@ -110,7 +111,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             Pageable pageable
-    ) throws UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException {
         User foundUser = validateEditDeleteAccess(currentUser, pathUsername);
         ProfileResponseDTO foundProfile = ProfileMapper.profileToResponseDTO(foundUser.getProfile());
         Page<BookSearchResultDTO> savedThemes = bookService.findSavedBooks(foundUser, pageable);
@@ -126,7 +127,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             ProfileEditRequestDTO editRequest
-    ) throws UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException {
         User foundUser = validateEditDeleteAccess(currentUser, pathUsername);
         ProfileResponseDTO foundProfile = ProfileMapper.profileToResponseDTO(foundUser.getProfile());
         ProfileEditRequestDTO profileEditRequestDTO =
@@ -145,7 +146,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             ProfileEditRequestDTO editRequest
-    ) throws UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException {
         User foundUser = validateEditDeleteAccess(currentUser, pathUsername);
         ProfileResponseDTO foundProfile = ProfileMapper.profileToResponseDTO(foundUser.getProfile());
         return new ProfileEditModel(
@@ -160,7 +161,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             ProfileEditRequestDTO editRequest
-    ) throws IllegalStateException, UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, IllegalStateException, UnauthorizedException, UserNotFoundException {
         Result<User, String> validUserOrRedirect = validateEditDeleteAccessAndRequest(
                 currentUser,
                 pathUsername,
@@ -184,7 +185,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             UserDeleteRequestDTO deleteRequest
-    ) throws UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException {
         User foundUser = validateEditDeleteAccess(currentUser, pathUsername);
         ProfileResponseDTO foundProfile = ProfileMapper.profileToResponseDTO(foundUser.getProfile());
         return new ProfileDeleteModel(
@@ -199,7 +200,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
             User currentUser,
             String pathUsername,
             UserDeleteRequestDTO deleteRequest
-    ) throws IllegalStateException, UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, IllegalStateException, UnauthorizedException, UserNotFoundException {
         Result<User, String> validUserOrRedirect = validateEditDeleteAccessAndRequest(
                 currentUser,
                 pathUsername,
@@ -276,7 +277,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
     private User validateEditDeleteAccess(
             User currentUser,
             String pathUsername
-    ) throws UnauthorizedException, UserNotFoundException {
+    ) throws ForbiddenException, UnauthorizedException, UserNotFoundException {
         User foundUser = pathUsername.equals("me")
                 ? currentUser
                 : userService
@@ -285,7 +286,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
         // anon /userA/action -> no
         // anon no request /userA/action -> no
         if (currentUser == null && !pathUsername.equals("me"))
-            throw new UnauthorizedException("You cannot modify %s's profile".formatted(pathUsername));
+            throw new ForbiddenException("You cannot modify %s's profile".formatted(pathUsername));
         // anon /me/action -> no
         // anon no request /me/action -> no
         if (currentUser == null)
@@ -293,7 +294,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
         // userB /userA/action -> no
         // userB no request /userA/action -> no
         if (!pathUsername.equals("me") && !currentUser.getUsername().equals(pathUsername))
-            throw new UnauthorizedException("You cannot modify %s's profile".formatted(pathUsername));
+            throw new ForbiddenException("You cannot modify %s's profile".formatted(pathUsername));
         // userA /userA/action -> ok
         // userA no request /userA/action -> ok
         // userA /me/action -> ok

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -250,7 +250,7 @@ body {
     justify-self: end;
 }
 
-.header-top-right-button {
+#header-top-right-div .header-top-right-button {
     font-size: 16px;
     background-color: var(--color-02, #F61590);
     border: 1px solid var(--color-06, #FFE2E7);
@@ -273,7 +273,7 @@ body {
     grid-gap: 5px;
 }
 
-#header-support {
+#header-top-right-div #header-support {
     padding-left: 25px;
     border-bottom-left-radius: 50px;
 }

--- a/src/main/resources/static/css/theme.css
+++ b/src/main/resources/static/css/theme.css
@@ -87,10 +87,10 @@
     grid-area: render;
     z-index: 0;
     color: var(--font-color, black);
+}
 
-    a {
-        color: var(--link-color, blue);
-    }
+#theme-preview-render a:not(.genre-oval, .header-top-right-button) {
+    color: var(--link-color, blue);
 }
 
 #theme-preview-render #header-navbar {

--- a/src/main/resources/templates/book-review.html
+++ b/src/main/resources/templates/book-review.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.review.title
+        + ' by ' + viewModel.review.userDisplayName}">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/book.html
+++ b/src/main/resources/templates/book.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + book.title
+        + ' by ' + book.author}">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + title}">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title>Bookstore - Books I have at home :D</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-delete-result.html
+++ b/src/main/resources/templates/profile-delete-result.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title>Bookstore - Deleted Account Successfully</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-delete.html
+++ b/src/main/resources/templates/profile-delete.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.user.username}
+        + ' - Delete Account'">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-edit-confirm.html
+++ b/src/main/resources/templates/profile-edit-confirm.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + profileEditRequestDTO.username}
+        + ' - Confirm Edit Account'">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-edit-result.html
+++ b/src/main/resources/templates/profile-edit-result.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title>Bookstore - Edited Account Successfully</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-edit.html
+++ b/src/main/resources/templates/profile-edit.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.user.username}
+        + ' - Edit Account'">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-saved-books.html
+++ b/src/main/resources/templates/profile-saved-books.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.user.username}
+        + ' - Saved Books'">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile-saved-themes.html
+++ b/src/main/resources/templates/profile-saved-themes.html
@@ -4,7 +4,8 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.user.username}
+        + ' - Saved Themes'">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/profile.html
+++ b/src/main/resources/templates/profile.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.user.username}">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/register-confirm.html
+++ b/src/main/resources/templates/register-confirm.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title>Bookstore - Confirm Create Account</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/register-result.html
+++ b/src/main/resources/templates/register-result.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title>Bookstore - Created Account Successfully</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title>Bookstore - Create Account</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -4,7 +4,10 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - Search ' + #strings.toLowerCase(param.type[0])
+        + (param.query != null
+            ? ' ' + param.query[0]
+            : '' )}">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">

--- a/src/main/resources/templates/theme.html
+++ b/src/main/resources/templates/theme.html
@@ -4,7 +4,7 @@
       xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>Bookstore</title>
+    <title th:text="${'Bookstore - ' + viewModel.theme.name}">Bookstore</title>
     <script src="http://localhost:35729/livereload.js"></script>
     <link href="/css/variables.css" rel="stylesheet">
     <link href="/css/style.css" rel="stylesheet">


### PR DESCRIPTION
closes #9, #15

---

# New
1. all pages have custom titles instead of just `Bookstore`
2. `ForbiddenException` to differentiate between 401 (Unauthorized) and 403 (Forbidden)

# Changes
1. some unauthorized exceptions were turned into forbidden
2. when visiting `/error` manually, show custom message
<img width="717" height="327" alt="image" src="https://github.com/user-attachments/assets/5a9339b8-c575-47df-a9e0-a51843ddf996" />

# etc
- add kaomoji to credits section
