### PR TITLE
Feat/latest themes

### DIFF
--- a/src/main/java/com/simple/Bookstore/Theme/ThemeRepository.java
+++ b/src/main/java/com/simple/Bookstore/Theme/ThemeRepository.java
@@ -14,28 +14,9 @@ import java.util.Optional;
 
 @Repository
 public interface ThemeRepository extends JpaRepository<Theme, Long> {
-    List<Theme> findByProfileUserOrderByName(User user);
-
-    Page<Theme> findByPublishedIsTrue(Pageable pageable);
-
     Optional<Theme> findByIdAndPublishedIsTrue(Long id);
 
     Optional<Theme> findByName(String name);
-
-    @Query(value = """
-            SELECT t from Theme t
-            WHERE (t.published = true AND t.profile.isPublic = true)
-                OR (:user IS NOT NULL AND t.profile.user = :user)
-            """)
-    Page<Theme> findByPublishedOrOwnedUnpublishedThemes(@Param("user") User user, Pageable pageable);
-
-    @Query("""
-            SELECT t.id
-            FROM Theme t
-            LEFT JOIN t.savedByProfiles p
-            WHERE p.id = :profileId
-            """)
-    List<Long> findProfileSavedThemeIds(@Param("profileId") Long profileId);
 
     @Query("""
             SELECT new com.simple.Bookstore.Theme.ThemeResponseDTO(
@@ -53,6 +34,25 @@ public interface ThemeRepository extends JpaRepository<Theme, Long> {
             @Param("profileId") Long profileId
     );
 
+    List<Theme> findByProfileUserOrderByName(User user);
+
+
+    @Query("""
+            SELECT t.id
+            FROM Theme t
+            LEFT JOIN t.savedByProfiles p
+            WHERE p.id = :profileId
+            """)
+    List<Long> findProfileSavedThemeIds(@Param("profileId") Long profileId);
+
+    Page<Theme> findByPublishedIsTrue(Pageable pageable);
+
+    @Query(value = """
+            SELECT t from Theme t
+            WHERE (t.published = true AND t.profile.isPublic = true)
+                OR (:user IS NOT NULL AND t.profile.user = :user)
+            """)
+    Page<Theme> findByPublishedOrOwnedUnpublishedThemes(@Param("user") User user, Pageable pageable);
 
     @Query("""
             SELECT new com.simple.Bookstore.Theme.ThemeResponseDTO(

--- a/src/main/java/com/simple/Bookstore/Theme/ThemeRepository.java
+++ b/src/main/java/com/simple/Bookstore/Theme/ThemeRepository.java
@@ -36,6 +36,23 @@ public interface ThemeRepository extends JpaRepository<Theme, Long> {
 
     List<Theme> findByProfileUserOrderByName(User user);
 
+    @Query("""
+            SELECT new com.simple.Bookstore.Theme.ThemeResponseDTO(
+                t.id, t.name, t.description, t.date, p.id, u.username, p.displayName,
+                t.base00, t.base01, t.base02, t.base03, t.base04, t.base05, t.base06, t.base07
+            )
+            FROM Theme t
+            LEFT JOIN t.profile p
+            LEFT JOIN p.user u
+            WHERE (t.published = true AND t.profile.isPublic = true)
+                OR (:user IS NOT NULL AND t.profile.user = :user)
+            ORDER BY t.date DESC, t.id DESC
+            LIMIT :n
+            """)
+    List<ThemeResponseDTO> findLatestNPublishedOrOwnedThemes(
+            @Param("user") User user,
+            @Param("n") int n
+    );
 
     @Query("""
             SELECT t.id

--- a/src/main/java/com/simple/Bookstore/Theme/ThemeService.java
+++ b/src/main/java/com/simple/Bookstore/Theme/ThemeService.java
@@ -12,29 +12,21 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ThemeService {
-    Page<ThemeResponseDTO> findPublishedOrOwnedUnpublishedThemes(User user, Pageable pageable);
-
-    List<ThemeResponseDTO> findThemesByUser(User user);
-
-    Page<ThemeResponseDTO> findThemesByUser(User profileUser, User visitor, Pageable pageable);
+    String getThemeAsInlineCss(Long id, User user, int steps) throws ThemeNotFoundException;
 
     Optional<ThemeResponseDTO> findPublishedOrOwnedThemeById(User user, Long themeId) throws ThemeNotFoundException;
 
-    ThemeResponseDTO findPublishedThemeById(Long id);
-
-    ThemeResponseDTO createTheme(User user, ThemeRequestDTO request);
-
-    ThemeResponseDTO updateTheme(Long id, ThemeRequestDTO request, User user) throws ThemeNotFoundException;
-
-    ThemeResponseDTO publishTheme(Long id, User user) throws ThemeNotFoundException;
-
-    ThemeResponseDTO makeThemePrivate(Long id, User user) throws ThemeNotFoundException;
-
-    ThemeResponseDTO saveThemeForUser(Long id, User user) throws ThemeNotFoundException;
-
-    void deleteTheme(Long id, User user) throws ThemeNotFoundException;
-
-    void deleteThemeFromSavedThemes(Long id, User user) throws ThemeNotFoundException;
+    /**
+     * @param user User / null: when anonymous, this is null
+     * @return ThemeResponseDTO / null: Returns the currently used theme by the
+     * authenticated user. If the user is anonymous or is an authenticated user
+     * but did not override the default theme, this will return null, which
+     * indicates that there is no override for the default theme.
+     * @throws IllegalStateException when the database cannot find the default
+     *                               theme, which should be there as the first
+     *                               entry
+     */
+    ThemeResponseDTO findUsedTheme(User user);
 
     /**
      * Use to create a request to create a theme from a yaml scheme.
@@ -53,29 +45,39 @@ public interface ThemeService {
             @Nullable String customDescription
     ) throws IOException;
 
+    ThemeResponseDTO findPublishedThemeById(Long id);
+
+    ThemeResponseDTO createTheme(User user, ThemeRequestDTO request);
+
+    ThemeResponseDTO updateTheme(Long id, ThemeRequestDTO request, User user) throws ThemeNotFoundException;
+
+    ThemeResponseDTO publishTheme(Long id, User user) throws ThemeNotFoundException;
+
+    ThemeResponseDTO makeThemePrivate(Long id, User user) throws ThemeNotFoundException;
+
+    ThemeResponseDTO saveThemeForUser(Long id, User user) throws ThemeNotFoundException;
+
+    void deleteTheme(Long id, User user) throws ThemeNotFoundException;
+
+    void deleteThemeFromSavedThemes(Long id, User user) throws ThemeNotFoundException;
+
+    List<ThemeResponseDTO> findLatestNPublishedOrOwnedThemes(User user, int n);
+
+    List<ThemeResponseDTO> findThemesByUser(User user);
+
+    List<ThemeResponseDTO> findSavedThemes(User user);
+
+    List<Long> findSavedThemeIds(User user);
+
+    Page<ThemeResponseDTO> findPublishedOrOwnedUnpublishedThemes(User user, Pageable pageable);
+
+    Page<ThemeResponseDTO> findThemesByUser(User profileUser, User visitor, Pageable pageable);
+
     Page<ThemeResponseDTO> searchThemes(
             Optional<String> query,
             User user,
             Pageable pageable
     ) throws ThemeNotFoundException;
-
-    String getThemeAsCss(Long id, User user, int steps) throws ThemeNotFoundException;
-
-    /**
-     * @param user User / null: when anonymous, this is null
-     * @return ThemeResponseDTO / null: Returns the currently used theme by the
-     * authenticated user. If the user is anonymous or is an authenticated user
-     * but did not override the default theme, this will return null, which
-     * indicates that there is no override for the default theme.
-     * @throws IllegalStateException when the database cannot find the default
-     *                               theme, which should be there as the first
-     *                               entry
-     */
-    ThemeResponseDTO findUsedTheme(User user);
-
-    List<ThemeResponseDTO> findSavedThemes(User user);
-
-    List<Long> findSavedThemeIds(User user);
 
     Page<ThemeResponseDTO> findSavedThemes(User user, Pageable pageable);
 }

--- a/src/main/java/com/simple/Bookstore/Theme/ThemeServiceImpl.java
+++ b/src/main/java/com/simple/Bookstore/Theme/ThemeServiceImpl.java
@@ -246,8 +246,9 @@ public class ThemeServiceImpl implements ThemeService {
     }
 
     @Override
-        return List.of();
     public List<ThemeResponseDTO> findLatestNPublishedOrOwnedThemes(User user, int n) {
+        return themeRepository
+                .findLatestNPublishedOrOwnedThemes(user, n);
     }
 
     @Override

--- a/src/main/java/com/simple/Bookstore/seeders/ThemeSeeder.java
+++ b/src/main/java/com/simple/Bookstore/seeders/ThemeSeeder.java
@@ -38,13 +38,13 @@ public class ThemeSeeder implements CommandLineRunner {
         if (!activeProfile.equals("dev"))
             return;
 
-        log.info("Seeding builtin themes...");
-        seedBuiltinThemes();
-
         log.info("Seeding themes...");
         seedThemesForUser(adminUsername);
         seedThemesForUser("user1");
         seedThemesForUser("user2");
+
+        log.info("Seeding builtin themes...");
+        seedBuiltinThemes();
     }
 
     private void seedBuiltinThemes() throws IOException {

--- a/src/main/java/com/simple/Bookstore/views/HomeViewController.java
+++ b/src/main/java/com/simple/Bookstore/views/HomeViewController.java
@@ -33,7 +33,7 @@ public class HomeViewController {
         model.addAttribute("bannerBooks", latestBooks.subList(0, Math.min(6, latestBooks.size())));
 
         model.addAttribute(
-                "viewThemesListModel",
+                "viewThemesAsListModel",
                 new ViewThemesAsListModel(
                         themeService.findLatestNPublishedOrOwnedThemes(user, 5),
                         themeService.findUsedTheme(user),

--- a/src/main/java/com/simple/Bookstore/views/HomeViewController.java
+++ b/src/main/java/com/simple/Bookstore/views/HomeViewController.java
@@ -5,6 +5,7 @@ import com.simple.Bookstore.Book.BookService;
 import com.simple.Bookstore.Review.ReviewService;
 import com.simple.Bookstore.Theme.ThemeService;
 import com.simple.Bookstore.User.User;
+import com.simple.Bookstore.views.SharedModels.ViewThemesAsListModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -31,7 +32,13 @@ public class HomeViewController {
         List<BookPreviewDTO> latestBooks = bookService.findLatestNBooks(10);
         model.addAttribute("bannerBooks", latestBooks.subList(0, Math.min(6, latestBooks.size())));
 
-        // TODO: latest themes with format "2 days ago. <username> just created <theme-name>.\n<description: 50 char cutoff>"
+        model.addAttribute(
+                "viewThemesListModel",
+                new ViewThemesAsListModel(
+                        themeService.findLatestNPublishedOrOwnedThemes(user, 5),
+                        themeService.findUsedTheme(user),
+                        themeService.findSavedThemeIds(user)
+                ));
 
         model.addAttribute("latestUploads", latestBooks.subList(0, Math.min(4, latestBooks.size())));
         model.addAttribute("availableBooks", bookService.findRelevantBooks(12));

--- a/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewController.java
+++ b/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewController.java
@@ -12,7 +12,7 @@ import com.simple.Bookstore.User.UserService;
 import com.simple.Bookstore.User.UserUpdateRequestDTO;
 import com.simple.Bookstore.utils.Result;
 import com.simple.Bookstore.views.HeaderAndSidebarsModelAttributes;
-import com.simple.Bookstore.views.SharedModels.ViewThemesModel;
+import com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -56,7 +56,7 @@ public class ProfileViewController {
         model.addAttribute("viewType", actualView);
         switch (actualView) {
             case THEMES:
-                Pair<ProfileViewModel, ViewThemesModel> pairThemes = profileViewService
+                Pair<ProfileViewModel, ViewThemesAsPageModel> pairThemes = profileViewService
                         .buildProfileViewThemes(user, pathUsername, pageable);
                 model.addAttribute("viewModel", pairThemes.getFirst());
                 model.addAttribute("viewThemesModel", pairThemes.getSecond());
@@ -88,7 +88,7 @@ public class ProfileViewController {
             Model model,
             @PageableDefault Pageable pageable
     ) {
-        Pair<ProfileViewModel, ViewThemesModel> pairModels = profileViewService
+        Pair<ProfileViewModel, ViewThemesAsPageModel> pairModels = profileViewService
                 .buildProfileViewSavedThemes(user, pathUsername, pageable);
         model.addAttribute("viewModel", pairModels.getFirst());
         model.addAttribute("viewSavedThemesModel", pairModels.getSecond());

--- a/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewController.java
+++ b/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewController.java
@@ -59,7 +59,7 @@ public class ProfileViewController {
                 Pair<ProfileViewModel, ViewThemesAsPageModel> pairThemes = profileViewService
                         .buildProfileViewThemes(user, pathUsername, pageable);
                 model.addAttribute("viewModel", pairThemes.getFirst());
-                model.addAttribute("viewThemesModel", pairThemes.getSecond());
+                model.addAttribute("viewThemesAsPageModel", pairThemes.getSecond());
                 break;
             case REVIEWS:
                 Pair<ProfileViewModel, ProfileViewReviewsModel> pairReviews = profileViewService

--- a/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewService.java
+++ b/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewService.java
@@ -7,7 +7,7 @@ import com.simple.Bookstore.Profile.ProfileEditRequestDTO;
 import com.simple.Bookstore.User.User;
 import com.simple.Bookstore.User.UserDeleteRequestDTO;
 import com.simple.Bookstore.utils.Result;
-import com.simple.Bookstore.views.SharedModels.ViewThemesModel;
+import com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.util.Pair;
 
@@ -20,7 +20,7 @@ public interface ProfileViewService {
      * @throws UnauthorizedException when you need to log in to access /profile/me
      * @throws UserNotFoundException when user with username is not found
      */
-    Pair<ProfileViewModel, ViewThemesModel> buildProfileViewThemes(
+    Pair<ProfileViewModel, ViewThemesAsPageModel> buildProfileViewThemes(
             User currentUser,
             String pathUsername,
             Pageable pageable
@@ -62,7 +62,7 @@ public interface ProfileViewService {
      * @throws UnauthorizedException when you need to log in to access /profile/me
      * @throws UserNotFoundException when user with username is not found
      */
-    Pair<ProfileViewModel, ViewThemesModel> buildProfileViewSavedThemes(
+    Pair<ProfileViewModel, ViewThemesAsPageModel> buildProfileViewSavedThemes(
             User currentUser,
             String pathUsername,
             Pageable pageable

--- a/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewServiceImpl.java
+++ b/src/main/java/com/simple/Bookstore/views/Profile/ProfileViewServiceImpl.java
@@ -19,7 +19,7 @@ import com.simple.Bookstore.User.UserService;
 import com.simple.Bookstore.utils.FormRequest;
 import com.simple.Bookstore.utils.ProfileMapper;
 import com.simple.Bookstore.utils.Result;
-import com.simple.Bookstore.views.SharedModels.ViewThemesModel;
+import com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,7 +38,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
     private final BookService bookService;
 
     @Override
-    public Pair<ProfileViewModel, ViewThemesModel> buildProfileViewThemes(
+    public Pair<ProfileViewModel, ViewThemesAsPageModel> buildProfileViewThemes(
             User currentUser,
             String pathUsername,
             Pageable pageable
@@ -53,7 +53,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
                 .toList();
         return Pair.of(
                 profileViewModel,
-                new ViewThemesModel(ownedThemes, usedTheme, savedThemeIds)
+                new ViewThemesAsPageModel(ownedThemes, usedTheme, savedThemeIds)
         );
     }
 
@@ -86,7 +86,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
     }
 
     @Override
-    public Pair<ProfileViewModel, ViewThemesModel> buildProfileViewSavedThemes(
+    public Pair<ProfileViewModel, ViewThemesAsPageModel> buildProfileViewSavedThemes(
             User currentUser,
             String pathUsername,
             Pageable pageable
@@ -102,7 +102,7 @@ public class ProfileViewServiceImpl implements ProfileViewService {
                 .toList();
         return Pair.of(
                 new ProfileViewModel(foundUser, foundProfile),
-                new ViewThemesModel(savedThemes, usedTheme, savedThemeIds)
+                new ViewThemesAsPageModel(savedThemes, usedTheme, savedThemeIds)
         );
     }
 

--- a/src/main/java/com/simple/Bookstore/views/SearchViewController.java
+++ b/src/main/java/com/simple/Bookstore/views/SearchViewController.java
@@ -12,7 +12,7 @@ import com.simple.Bookstore.Theme.ThemeService;
 import com.simple.Bookstore.User.User;
 import com.simple.Bookstore.views.SharedModels.ViewBooksModel;
 import com.simple.Bookstore.views.SharedModels.ViewProfilesModel;
-import com.simple.Bookstore.views.SharedModels.ViewThemesModel;
+import com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -91,7 +91,7 @@ public class SearchViewController {
                 model.addAttribute("results", results);
                 model.addAttribute(
                         "viewThemesModel",
-                        new ViewThemesModel(
+                        new ViewThemesAsPageModel(
                                 results,
                                 themeService.findUsedTheme(user),
                                 themeService.findSavedThemeIds(user)

--- a/src/main/java/com/simple/Bookstore/views/SearchViewController.java
+++ b/src/main/java/com/simple/Bookstore/views/SearchViewController.java
@@ -90,7 +90,7 @@ public class SearchViewController {
                 Page<ThemeResponseDTO> results = themeService.searchThemes(query, user, pageable);
                 model.addAttribute("results", results);
                 model.addAttribute(
-                        "viewThemesModel",
+                        "viewThemesAsPageModel",
                         new ViewThemesAsPageModel(
                                 results,
                                 themeService.findUsedTheme(user),

--- a/src/main/java/com/simple/Bookstore/views/SharedModels/ViewThemesAsListModel.java
+++ b/src/main/java/com/simple/Bookstore/views/SharedModels/ViewThemesAsListModel.java
@@ -1,0 +1,12 @@
+package com.simple.Bookstore.views.SharedModels;
+
+import com.simple.Bookstore.Theme.ThemeResponseDTO;
+
+import java.util.List;
+
+public record ViewThemesAsListModel(
+        List<ThemeResponseDTO> themes,
+        ThemeResponseDTO currentUserTheme,
+        List<Long> currentUserSavedThemeIds
+) {
+}

--- a/src/main/java/com/simple/Bookstore/views/SharedModels/ViewThemesAsPageModel.java
+++ b/src/main/java/com/simple/Bookstore/views/SharedModels/ViewThemesAsPageModel.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-public record ViewThemesModel(
+public record ViewThemesAsPageModel(
         Page<ThemeResponseDTO> themes,
         ThemeResponseDTO currentUserTheme,
         List<Long> currentUserSavedThemeIds

--- a/src/main/resources/static/css/components/themes-section.css
+++ b/src/main/resources/static/css/components/themes-section.css
@@ -9,7 +9,7 @@
     border: 2px solid var(--color-00, #A40E60);
 }
 
-.theme-item ul {
+.theme-item > ul {
     grid-area: preview;
     display: grid;
     grid-template-columns: repeat(8, 1fr);
@@ -21,19 +21,19 @@
     place-items: center;
 }
 
-.theme-item ul li {
+.theme-item > ul li {
     width: 17px;
     min-height: 17px;
     height: 100%;
     aspect-ratio: 1;
 }
 
-.theme-item ul li:first-child {
+.theme-item > ul li:first-child {
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
 }
 
-.theme-item ul li:last-child {
+.theme-item > ul li:last-child {
     border-top-right-radius: 10px;
     border-bottom-right-radius: 10px;
 }

--- a/src/main/resources/static/css/index.css
+++ b/src/main/resources/static/css/index.css
@@ -52,6 +52,145 @@
     pointer-events: none;
 }
 
+#latest-themes {
+    display: grid;
+    grid-template-rows: repeat(3, auto);
+    grid-template-columns: 117px 1fr;
+    grid-template-areas:
+            'logo themes'
+            'link themes'
+            'title themes';
+    background-color: var(--color-02, #F61590);
+    border: 1px solid var(--color-00, #A40E60);
+}
+
+#latest-themes > div:first-child {
+    grid-area: logo;
+    justify-self: center;
+    align-self: end;
+}
+
+#latest-themes > div:first-child svg text {
+    font-size: 60px;
+}
+
+#latest-themes > div:nth-child(2) {
+    grid-area: link;
+    justify-self: center;
+    align-self: center;
+
+    font-size: 6px;
+    text-align: center;
+
+    .text-outline-outer {
+        fill: none;
+        paint-order: stroke;
+        stroke: none;
+    }
+
+    .text-outline-inner {
+        fill: none;
+        paint-order: stroke;
+        stroke: var(--color-06, #FFE2E7);
+        stroke-linejoin: round;
+        stroke-width: 2;
+    }
+
+    .text-fill {
+        fill: var(--color-02, #F61590);
+    }
+}
+
+#latest-themes > h4 {
+    grid-area: title;
+    color: var(--color-06, #FFE2E7);
+    text-align: center;
+    margin: 0;
+}
+
+#latest-themes-list {
+    grid-area: themes;
+    display: flex;
+    flex-direction: column;
+    row-gap: 10px;
+    max-height: 70px;
+    overflow-y: scroll;
+    background-color: var(--color-06, #FFE2E7);
+    border-color: var(--color-00, #A40E60) var(--color-02, #F61590) var(--color-02, #F61590) var(--color-00, #A40E60);
+    border-width: 3px;
+    border-style: inset;
+}
+
+.latest-theme {
+    display: grid;
+    grid-template-rows: repeat(2, auto);
+    grid-template-columns: 131px 1fr repeat(2, 52px);
+    grid-template-areas:
+            'date title preview preview'
+            'date description apply save';
+    grid-column-gap: 10px;
+    grid-row-gap: 0;
+    padding: 5px 15px 5px 5px;
+
+    > ul {
+        grid-area: preview;
+        display: flex;
+        flex-direction: row;
+        column-gap: 0;
+        padding: 5px;
+        margin: 0;
+        list-style: none;
+        background: rgba(0, 0, 0, 0.1);
+        border-radius: 10px;
+    }
+
+    > ul li {
+        width: 13px;
+        min-height: 13px;
+        height: 100%;
+        aspect-ratio: 1;
+    }
+
+    > ul li:first-child {
+        border-top-left-radius: 10px;
+        border-bottom-left-radius: 10px;
+    }
+
+    > ul li:last-child {
+        border-top-right-radius: 10px;
+        border-bottom-right-radius: 10px;
+    }
+
+    > strong {
+        grid-area: date;
+        color: var(--color-01, #FF0000);
+        align-self: center;
+        text-align: center;
+    }
+
+    > p {
+        margin: 0;
+    }
+
+    > p:first-of-type {
+        grid-area: title;
+    }
+
+    > p:nth-of-type(2) {
+        grid-area: description;
+    }
+
+    .latest-theme-apply {
+        grid-area: apply;
+        align-self: center;
+    }
+
+    .latest-theme-save {
+        grid-area: save;
+        align-self: center;
+    }
+}
+
 .book-list-content-div {
     display: flex;
     flex-direction: column;

--- a/src/main/resources/templates/fragments/components/themes-section.html
+++ b/src/main/resources/templates/fragments/components/themes-section.html
@@ -8,7 +8,7 @@
     <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 
 <th:block th:fragment="themes(viewThemesModel)">
     <th:block th:if="${!viewThemesModel.themes().hasContent()}">No results found...</th:block>

--- a/src/main/resources/templates/fragments/components/themes-section.html
+++ b/src/main/resources/templates/fragments/components/themes-section.html
@@ -8,53 +8,86 @@
     <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
+<!--/*@thymesVar id="viewThemesAsPageModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
+<th:block th:fragment="themesPage(viewThemesAsPageModel)">
+    <th:block th:if="${!viewThemesAsPageModel.themes().hasContent()}">No results found...</th:block>
+    <div th:replace="~{fragments/components/themes-section.html
+        :: _themeList(
+            ${viewThemesAsPageModel.themes},
+            ${viewThemesAsPageModel.currentUserTheme},
+            ${viewThemesAsPageModel.currentUserSavedThemeIds}
+        )}"></div>
+</th:block>
 
-<th:block th:fragment="themes(viewThemesModel)">
-    <th:block th:if="${!viewThemesModel.themes().hasContent()}">No results found...</th:block>
-    <div class="theme-item" th:each="theme, i : ${viewThemesModel.themes()}">
-        <ul>
-            <li th:style="'background-color: #' + ${theme.base00} " th:title="'#' + ${theme.base00}"></li>
-            <li th:style="'background-color: #' + ${theme.base01} " th:title="'#' + ${theme.base01}"></li>
-            <li th:style="'background-color: #' + ${theme.base02} " th:title="'#' + ${theme.base02}"></li>
-            <li th:style="'background-color: #' + ${theme.base03} " th:title="'#' + ${theme.base03}"></li>
-            <li th:style="'background-color: #' + ${theme.base04} " th:title="'#' + ${theme.base04}"></li>
-            <li th:style="'background-color: #' + ${theme.base05} " th:title="'#' + ${theme.base05}"></li>
-            <li th:style="'background-color: #' + ${theme.base06} " th:title="'#' + ${theme.base06}"></li>
-            <li th:style="'background-color: #' + ${theme.base07} " th:title="'#' + ${theme.base07}"></li>
-        </ul>
-        <p class="theme-title">
-            <a th:href="@{/themes/{id}(id=${theme.id})}"
-               th:text="${#strings.isEmpty(theme.name) ? 'Theme ' + theme.id : theme.name}"></a>
-        </p>
-        <th:block th:if="${!#strings.isEmpty(theme.description)}">
-            <strong class="theme-details-label">Description: </strong>
-            <p class="theme-details-value" th:text="${theme.description}"></p>
+<!--/*@thymesVar id="themes" type="java.util.List<Theme>"*/-->
+<!--/*@thymesVar id="currentUserTheme" type="com.simple.Bookstore.Theme.ThemeResponseDTO"*/-->
+<!--/*@thymesVar id="currentUserSavedThemeIds" type="java.util.List<java.lang.Long>"*/-->
+<div class="theme-item" th:each="theme, i : ${themes}"
+     th:fragment="_themeList(themes, currentUserTheme, currentUserSavedThemeIds)">
+    <ul th:replace="~{fragments/components/themes-section.html :: _themePreview(${theme})}"></ul>
+    <p class="theme-title">
+        <a th:href="@{/themes/{id}(id=${theme.id})}"
+           th:text="${#strings.isEmpty(theme.name) ? 'Theme ' + theme.id : theme.name}"></a>
+    </p>
+    <th:block th:if="${!#strings.isEmpty(theme.description)}">
+        <strong class="theme-details-label">Description: </strong>
+        <p class="theme-details-value" th:text="${theme.description}"></p>
+    </th:block>
+    <th:block th:replace="~{fragments/components/themes-section.html
+        :: _themeApplyAndSaveButtons(
+            ${theme},
+            ${currentUserTheme},
+            ${currentUserSavedThemeIds},
+            'theme-details-label',
+            'theme-details-value'
+        )}">
+    </th:block>
+</div>
+
+<!--/*@thymesVar id="themes" type="com.simple.Bookstore.Theme.Theme"*/-->
+<!--/*@thymesVar id="ulClass" type="java.lang.String"*/-->
+<ul th:fragment="_themePreview(theme)">
+    <li th:style="'background-color: #' + ${theme.base00} " th:title="'#' + ${theme.base00}"></li>
+    <li th:style="'background-color: #' + ${theme.base01} " th:title="'#' + ${theme.base01}"></li>
+    <li th:style="'background-color: #' + ${theme.base02} " th:title="'#' + ${theme.base02}"></li>
+    <li th:style="'background-color: #' + ${theme.base03} " th:title="'#' + ${theme.base03}"></li>
+    <li th:style="'background-color: #' + ${theme.base04} " th:title="'#' + ${theme.base04}"></li>
+    <li th:style="'background-color: #' + ${theme.base05} " th:title="'#' + ${theme.base05}"></li>
+    <li th:style="'background-color: #' + ${theme.base06} " th:title="'#' + ${theme.base06}"></li>
+    <li th:style="'background-color: #' + ${theme.base07} " th:title="'#' + ${theme.base07}"></li>
+</ul>
+
+<!--/*@thymesVar id="themes" type="com.simple.Bookstore.Theme.Theme"*/-->
+<!--/*@thymesVar id="currentUserTheme" type="com.simple.Bookstore.Theme.ThemeResponseDTO"*/-->
+<!--/*@thymesVar id="currentUserSavedThemeIds" type="java.util.List<java.lang.Long>"*/-->
+<th:block sec:authorize="isAuthenticated()"
+          th:fragment="_themeApplyAndSaveButtons(
+              theme,
+              currentUserTheme,
+              currentUserSavedThemeIds,
+              applyClass,
+              saveClass)">
+    <form action="#" method="post" th:action="@{/profile/theme}" th:class="${applyClass != null ? applyClass : ''}">
+        <input name="themeId" th:value="${theme.id}" type="hidden" />
+        <button th:if="${currentUserTheme == null}" type="submit">Apply</button>
+        <th:block th:if="${currentUserTheme != null}">
+            <i th:if="${currentUserTheme.id == theme.id}">In Use</i>
+            <button th:if="${currentUserTheme.id != theme.id}" type="submit">Apply</button>
         </th:block>
-        <th:block sec:authorize="isAuthenticated()">
-            <form action="#" class="theme-details-label" method="post" th:action="@{/profile/theme}">
-                <input name="themeId" th:value="${theme.id}" type="hidden" />
-                <button th:if="${viewThemesModel.currentUserTheme() == null}" type="submit">Apply</button>
-                <th:block th:if="${viewThemesModel.currentUserTheme() != null}">
-                    <i th:if="${viewThemesModel.currentUserTheme().id == theme.id}">In Use</i>
-                    <button th:if="${viewThemesModel.currentUserTheme().id != theme.id}" type="submit">Apply</button>
-                </th:block>
-            </form>
-            <form action="#" class="theme-details-value" method="post"
-                  th:action="@{/profile/saved-themes}"
-                  th:if="${!#lists.contains(viewThemesModel.currentUserSavedThemeIds(), theme.id)}">
-                <input name="themeId" th:value="${theme.id}" type="hidden" />
-                <button type="submit">Save</button>
-            </form>
-            <form action="#" class="theme-details-value" method="post"
-                  th:action="@{/profile/saved-themes}"
-                  th:if="${#lists.contains(viewThemesModel.currentUserSavedThemeIds(), theme.id)}">
-                <input name="_method" type="hidden" value="delete" />
-                <input name="themeId" th:value="${theme.id}" type="hidden" />
-                <button type="submit">Unsave</button>
-            </form>
-        </th:block>
-    </div>
+    </form>
+    <form action="#" method="post" th:action="@{/profile/saved-themes}"
+          th:class="${saveClass != null ? saveClass : ''}"
+          th:if="${!#lists.contains(currentUserSavedThemeIds, theme.id)}">
+        <input name="themeId" th:value="${theme.id}" type="hidden" />
+        <button type="submit">Save</button>
+    </form>
+    <form action="#" method="post" th:action="@{/profile/saved-themes}"
+          th:class="${saveClass != null ? saveClass : ''}"
+          th:if="${#lists.contains(currentUserSavedThemeIds, theme.id)}">
+        <input name="_method" type="hidden" value="delete" />
+        <input name="themeId" th:value="${theme.id}" type="hidden" />
+        <button type="submit">Unsave</button>
+    </form>
 </th:block>
 
 </body>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -17,41 +17,7 @@
                 <div th:replace="~{fragments/svg-fragments/heading-plain :: svgHeading('Books I have at home :D', 179, 16)}"></div>
             </div>
             <div id="header-logo-div">
-                <a href="/">
-                    <div style="z-index: 9999; display: inline-block">
-                        <svg class="svg-text-heading" preserveAspectRatio="xMinYMid meet"
-                             style="overflow:visible; height:1em;"
-                             viewBox="0 0 340 60"
-                             xmlns="http://www.w3.org/2000/svg">
-                            <th:block th:each="letter, i : ${logoLetters}">
-                                <g
-                                        th:attr="transform=${letter.rotate != 0}
-                                    ? 'rotate(' + ${letter.rotate} + ',' + (${letter.xOffset + 35}) + ',35)'
-                                    : null">
-                                    <ellipse
-                                            class="letter-oval"
-                                            rx="24" ry="28"
-                                            th:attr="cx=${letter.xOffset + 18}, cy=${letter.yOffset + 35}" />
-                                </g>
-                            </th:block>
-                            <th:block th:each="letter, i : ${logoLetters}">
-                                <g
-                                        th:attr="transform=${letter.rotate != 0}
-                                    ? 'rotate(' + ${letter.rotate} + ',' + ${letter.xOffset + 35} + ',35)'
-                                    : null">
-                                    <!-- text outline -->
-                                    <text class="logo-letter-outline"
-                                          th:attr="x=${letter.xOffset}, y=${letter.yOffset}"
-                                          th:text="${letter.letter}"/>
-                                    <!-- text fill -->
-                                    <text th:attr="x=${letter.xOffset}, y=${letter.yOffset}"
-                                          th:id="${letter.htmlId}"
-                                          th:text="${letter.letter}" />
-                                </g>
-                            </th:block>
-                        </svg>
-                    </div>
-                </a>
+                <a href="/" th:insert="~{fragments/header.html :: siteLogo(340, 60)}"></a>
             </div>
             <div id="header-logo-link-div">
                 <a href="https://github.com/am-cid/bookstore" id="header-logo-link" target="_blank">
@@ -103,6 +69,40 @@
         </div>
     </div>
 </header>
+
+<div style="z-index: 9999; display: inline-block" th:fragment="siteLogo(viewWidth, viewHeight)">
+    <svg class="svg-text-heading" preserveAspectRatio="xMinYMid meet"
+         style="overflow:visible; height:1em;"
+         th:attr="viewBox='0 0 ' +  ${viewWidth} + ' ' + ${viewHeight}"
+         xmlns="http://www.w3.org/2000/svg">
+        <th:block th:each="letter, i : ${logoLetters}">
+            <g
+                    th:attr="transform=${letter.rotate != 0}
+                                    ? 'rotate(' + ${letter.rotate} + ',' + (${letter.xOffset + 35}) + ',35)'
+                                    : null">
+                <ellipse
+                        class="letter-oval"
+                        rx="24" ry="28"
+                        th:attr="cx=${letter.xOffset + 18}, cy=${letter.yOffset + 35}" />
+            </g>
+        </th:block>
+        <th:block th:each="letter, i : ${logoLetters}">
+            <g
+                    th:attr="transform=${letter.rotate != 0}
+                                    ? 'rotate(' + ${letter.rotate} + ',' + ${letter.xOffset + 35} + ',35)'
+                                    : null">
+                <!-- text outline -->
+                <text class="logo-letter-outline"
+                      th:attr="x=${letter.xOffset}, y=${letter.yOffset}"
+                      th:text="${letter.letter}"/>
+                <!-- text fill -->
+                <text th:attr="x=${letter.xOffset}, y=${letter.yOffset}"
+                      th:id="${letter.htmlId}"
+                      th:text="${letter.letter}" />
+            </g>
+        </th:block>
+    </svg>
+</div>
 
 </body>
 </html>

--- a/src/main/resources/templates/fragments/main-content.html
+++ b/src/main/resources/templates/fragments/main-content.html
@@ -6,16 +6,45 @@
     <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
+<!--/*@thymesVar id="viewThemesAsListModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsListModel"*/-->
 
 <div class="flex-column w-704px gap-10px" th:fragment="main-content">
     <!-- SLIDING BANNER -->
     <div th:replace="~{fragments/sliding-banner :: sliding-banner}"></div>
+    <!-- LATEST THEMES -->
+    <div th:replace="~{fragments/main-content.html :: latest-themes}"></div>
     <div id="main-content">
         <!-- LATEST UPLOADS -->
         <div th:replace="~{fragments/two-column-book-list :: twoColBookList(${latestUploads}, 'LATEST UPLOADS')}"></div>
         <!-- AVAILABLE BOOKS -->
         <div th:replace="~{fragments/two-column-book-list :: twoColBookList(${availableBooks}, 'AVAILABLE BOOKS')}"></div>
         <script th:src="@{/js/genre-expand.js}"></script>
+    </div>
+</div>
+
+<div id="latest-themes" th:fragment="latest-themes">
+    <div th:replace="~{fragments/header.html :: siteLogo(340, 60)}"></div>
+    <div th:replace="~{fragments/svg-fragments/heading-plain ::
+                    svgHeading('github.com/am-cid/bookstore', 82, 6)}"></div>
+    <h4>HOT THEMES</h4>
+    <div id="latest-themes-list" >
+        <th:block th:if="${viewThemesAsListModel.themes.isEmpty()}">No results found...</th:block>
+        <div class="latest-theme" th:each="theme, i : ${viewThemesAsListModel.themes}">
+            <ul th:replace="~{fragments/components/themes-section.html :: _themePreview(${theme})}"></ul>
+            <strong th:text="${#temporals.format(theme.date, 'dd MMMM yyyy')}"></strong>
+            <p><a th:href="@{/themes/{id}(id=${theme.id})}"
+               th:text="${#strings.isEmpty(theme.name) ? 'Theme ' + theme.id : theme.name}"></a></p>
+            <p th:text="${#strings.abbreviate(theme.description, 85)}"></p>
+            <th:block th:replace="~{fragments/components/themes-section.html
+                    :: _themeApplyAndSaveButtons(
+                        ${theme},
+                        ${viewThemesAsListModel.currentUserTheme},
+                        ${viewThemesAsListModel.currentUserSavedThemeIds},
+                        'latest-theme-apply',
+                        'latest-theme-save'
+                    )}">
+            </th:block>
+        </div>
     </div>
 </div>
 

--- a/src/main/resources/templates/fragments/profile-saved-section.html
+++ b/src/main/resources/templates/fragments/profile-saved-section.html
@@ -12,7 +12,7 @@
 <!--/*@thymesVar id="accountHeader" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
 <!--/*@thymesVar id="viewSavedBooksModel" type="com.simple.Bookstore.views.Profile.ProfileViewSavedBooksModel"*/-->
-<!--/*@thymesVar id="viewSavedThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewSavedThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 
 <div id="main-content" th:fragment="saved-themes">
     <div id="profile-div">

--- a/src/main/resources/templates/fragments/profile-saved-section.html
+++ b/src/main/resources/templates/fragments/profile-saved-section.html
@@ -22,7 +22,7 @@
             <div class="saved-section">
                 <h2>Saved Themes</h2>
                 <nav th:replace="~{fragments/components/pagination :: pagination(${viewSavedThemesModel.themes}, '/profile/' + ${pathUsername} + '/saved-themes', null)}"></nav>
-                <div th:replace="~{fragments/components/themes-section :: themes(${viewSavedThemesModel})}"></div>
+                <div th:replace="~{fragments/components/themes-section :: themesPage(${viewSavedThemesModel})}"></div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/fragments/profile.html
+++ b/src/main/resources/templates/fragments/profile.html
@@ -12,7 +12,7 @@
 <!--/*@thymesVar id="accountHeader" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewType" type="com.simple.Bookstore.views.Profile.ProfileViewType"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewReviewsModel" type="com.simple.Bookstore.views.Profile.ProfileViewReviewsModel"*/-->
 <!--/*@thymesVar id="viewCommentsModel" type="com.simple.Bookstore.views.Profile.ProfileViewCommentsModel"*/-->
 

--- a/src/main/resources/templates/fragments/profile/account-details.html
+++ b/src/main/resources/templates/fragments/profile/account-details.html
@@ -10,7 +10,7 @@
 <!--/*@thymesVar id="pathUsername" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewType" type="com.simple.Bookstore.views.Profile.ProfileViewType"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewReviewsModel" type="com.simple.Bookstore.views.Profile.ProfileViewReviewsModel"*/-->
 <!--/*@thymesVar id="viewCommentsModel" type="com.simple.Bookstore.views.Profile.ProfileViewCommentsModel"*/-->
 

--- a/src/main/resources/templates/fragments/profile/profile-comments.html
+++ b/src/main/resources/templates/fragments/profile/profile-comments.html
@@ -10,7 +10,7 @@
 <!--/*@thymesVar id="pathUsername" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewType" type="com.simple.Bookstore.views.Profile.ProfileViewType"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewReviewsModel" type="com.simple.Bookstore.views.Profile.ProfileViewReviewsModel"*/-->
 <!--/*@thymesVar id="viewCommentsModel" type="com.simple.Bookstore.views.Profile.ProfileViewCommentsModel"*/-->
 

--- a/src/main/resources/templates/fragments/profile/profile-reviews.html
+++ b/src/main/resources/templates/fragments/profile/profile-reviews.html
@@ -10,7 +10,7 @@
 <!--/*@thymesVar id="pathUsername" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewType" type="com.simple.Bookstore.views.Profile.ProfileViewType"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewReviewsModel" type="com.simple.Bookstore.views.Profile.ProfileViewReviewsModel"*/-->
 <!--/*@thymesVar id="viewCommentsModel" type="com.simple.Bookstore.views.Profile.ProfileViewCommentsModel"*/-->
 

--- a/src/main/resources/templates/fragments/profile/profile-themes.html
+++ b/src/main/resources/templates/fragments/profile/profile-themes.html
@@ -11,7 +11,7 @@
 <!--/*@thymesVar id="pathUsername" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewType" type="com.simple.Bookstore.views.Profile.ProfileViewType"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewReviewsModel" type="com.simple.Bookstore.views.Profile.ProfileViewReviewsModel"*/-->
 <!--/*@thymesVar id="viewCommentsModel" type="com.simple.Bookstore.views.Profile.ProfileViewCommentsModel"*/-->
 
@@ -20,7 +20,7 @@
         <div th:replace="~{fragments/profile/profile-view-dropdown :: view-dropdown}"></div>
         <div th:replace="~{fragments/components/pagination :: pagination(${viewThemesModel.themes}, '/profile/' + ${pathUsername}, null)}"></div>
     </div>
-    <th:block th:replace="~{fragments/components/themes-section :: themes(${viewThemesModel})}"></th:block>
+    <th:block th:replace="~{fragments/components/themes-section :: themesPage(${viewThemesModel})}"></th:block>
     <div th:replace="~{fragments/components/pagination :: pagination(${viewThemesModel.themes}, '/profile/' + ${pathUsername}, null)}"></div>
 </div>
 

--- a/src/main/resources/templates/fragments/profile/profile-view-dropdown.html
+++ b/src/main/resources/templates/fragments/profile/profile-view-dropdown.html
@@ -11,7 +11,7 @@
 <!--/*@thymesVar id="pathUsername" type="java.lang.String"*/-->
 <!--/*@thymesVar id="viewType" type="com.simple.Bookstore.views.Profile.ProfileViewType"*/-->
 <!--/*@thymesVar id="viewModel" type="com.simple.Bookstore.views.Profile.ProfileViewModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewReviewsModel" type="com.simple.Bookstore.views.Profile.ProfileViewReviewsModel"*/-->
 <!--/*@thymesVar id="viewCommentsModel" type="com.simple.Bookstore.views.Profile.ProfileViewCommentsModel"*/-->
 

--- a/src/main/resources/templates/fragments/search.html
+++ b/src/main/resources/templates/fragments/search.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <!--/*@thymesVar id="viewBooksModel" type="com.simple.Bookstore.views.SharedModels.ViewBooksModel"*/-->
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 <!--/*@thymesVar id="viewProfilesModel" type="com.simple.Bookstore.views.SharedModels.ViewProfilesModel"*/-->
 <!--/*@thymesVar id="queryString" type="java.lang.String"*/-->
 <!--/*@thymesVar id="results" type="org.springframework.data.domain.Page<T>"*/-->

--- a/src/main/resources/templates/fragments/search/theme.html
+++ b/src/main/resources/templates/fragments/search/theme.html
@@ -8,7 +8,7 @@
     <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesModel"*/-->
+<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 
 <div class="search-result-content-div" th:fragment="search-results">
     <div th:replace="~{fragments/svg-fragments/heading-plain :: svgHeading('Search:Theme', 1, 33)}"></div>

--- a/src/main/resources/templates/fragments/search/theme.html
+++ b/src/main/resources/templates/fragments/search/theme.html
@@ -8,13 +8,13 @@
     <link href="/css/style.css" rel="stylesheet">
 </head>
 <body>
-<!--/*@thymesVar id="viewThemesModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
+<!--/*@thymesVar id="viewThemesAsPageModel" type="com.simple.Bookstore.views.SharedModels.ViewThemesAsPageModel"*/-->
 
 <div class="search-result-content-div" th:fragment="search-results">
     <div th:replace="~{fragments/svg-fragments/heading-plain :: svgHeading('Search:Theme', 1, 33)}"></div>
     <div class="search-result-content flex-column">
         <i sec:authorize="isAnonymous()">Login to change theme</i>
-        <th:block th:replace="~{fragments/components/themes-section :: themes(${viewThemesModel})}"></th:block>
+        <th:block th:replace="~{fragments/components/themes-section :: themesPage(${viewThemesAsPageModel})}"></th:block>
     </div>
 </div>
 

--- a/src/main/resources/templates/fragments/two-column-book-list.html
+++ b/src/main/resources/templates/fragments/two-column-book-list.html
@@ -10,7 +10,7 @@
 
 <div class='flex-column' th:fragment="twoColBookList(bookDtoList, headingTitle)">
     <div class="book-list-content-div">
-        <div th:replace="~{fragments/svg-fragments/heading-followed-by-circles :: svgHeading(${headingTitle}, 290, 18, 4.5)}"></div>
+        <div th:replace="~{fragments/svg-fragments/heading-followed-by-circles :: svgHeading(${headingTitle}, 290, 18, 6)}"></div>
         <div class="book-list-content">
             <div class="book-list-item gap-10px" th:each="book : ${bookDtoList}">
                 <div class="book-list-item-image">


### PR DESCRIPTION
closes #13, closes #3 (stale since book search results have always had descriptions)

---

# New
1. hot themes section in home page (currently its just latest themes)
<img width="1094" height="894" alt="image" src="https://github.com/user-attachments/assets/d4de6902-e5bc-4278-a5be-0f64fca4a548" />
when logged in, apply and save buttons appear.
<img width="1065" height="498" alt="image" src="https://github.com/user-attachments/assets/469891d5-d8b1-436f-8339-1a8dbcb97af5" />


# Changes
none

# etc
- make circles following headings a bit larger to match mangagamer's design
<img width="695" height="464" alt="image" src="https://github.com/user-attachments/assets/ac7b1a10-97c6-426a-b976-572343804348" />

- rearrange theme service's methods
- have two view models for themes: a list one and a paged one
